### PR TITLE
Allow Array Responses

### DIFF
--- a/lib/easy_meli/api_client.rb
+++ b/lib/easy_meli/api_client.rb
@@ -51,9 +51,9 @@ class EasyMeli::ApiClient
   end
 
   def check_authentication(response)
-    response_message = error_message_from_body(response.to_h)
+    response_message = error_message_from_body(response.to_h) if response.parsed_response.is_a? Hash
     return if response_message.to_s.empty?
-    
+
     TOKEN_ERRORS.keys.each do |key|
       if response_message.include?(key)
         raise EasyMeli::AuthenticationError.new(TOKEN_ERRORS[key], response)

--- a/lib/easy_meli/version.rb
+++ b/lib/easy_meli/version.rb
@@ -1,3 +1,3 @@
 module EasyMeli
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end

--- a/test/api_client_test.rb
+++ b/test/api_client_test.rb
@@ -45,10 +45,16 @@ class ApiClientTest < Minitest::Test
     assert_authorization_error('message' => 'Malformed access_token')
   end
 
+  def test_array_response
+    stub_verb_request(:get, 'test', query: { param1: 1, param2: 2 }).
+      to_return(body: '[{}, {}]')
+    client.get('test', query: { param1: 1, param2: 2 })
+  end
+
   private
 
   def assert_authorization_error(body)
-    assert_raises EasyMeli::AuthenticationError do 
+    assert_raises EasyMeli::AuthenticationError do
       stub_verb_request(:get, 'test', query: { param1: 1, param2: 2 }).
         to_return(body: body.to_json)
       client.get('test', query: { param1: 1, param2: 2 })


### PR DESCRIPTION
check_authentication method explodes when the json response is an array.
This adds a validaton to avoid fail on to_h call.