### PR TITLE
Added helpers in EasyMeli doc but decided to updated old instance met…

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,26 +32,26 @@ end
 To get the authorization url that the end-user uses to give your app authorization to access MercadoLibre on your part call the `authorization_url` with the desired country and the url to redirect to in order to complete the authorization.
 
 ```ruby
-EasyMeli::AuthorizationClient.authorization_url('MX', 'your_redirect_url')
+EasyMeli.authorization_url('MX', 'your_redirect_url')
 ```
 
 Once MercadoLibre calls your redirect url you can get a refresh token by calling
 
 ```ruby
-response = EasyMeli::AuthorizationClient.new.create_token('the_code_in_the_redirect', 'the_same_redirect_url_as_above')
+response = EasyMeli.create_token('the_code_in_the_redirect', 'the_same_redirect_url_as_above')
 ```
 This will return a response object with a json body that you can easily access via `response.to_h`.
 
 If you want to refresh the token call 
 
 ```ruby
-response = EasyMeli::AuthorizationClient.new.refresh_token('a_refresh_token')
+access_token = EasyMeli.refresh_token('a_refresh_token')
 ```
 
 Once you can have an access token you can create a client and call the supported http verb methods.
 
 ```ruby
-client = EasyMeli::ApiClient.new(access_token)
+client = EasyMeli.api_client(refresh_token: refresh_token)
 
 client.get(path, query: { a: 1 })
 client.post(path, query: { a: 1 }, body: { b: 1 })
@@ -59,25 +59,21 @@ client.put(path, query: { a: 1 }, body: { b: 1 })
 client.delete(path, query: { a: 1 })
 ```
 
-You can also pass a logger when instantiating the `EasyMeli::ApiClient` or `EasyMeli::AuthorizationClient`. The logger class must implement a `log` method which will be called with the [HTTParty response](https://www.rubydoc.info/github/jnunemaker/httparty/HTTParty/Response) for every remote request sent.
+You can also pass a logger to any methods that make remote calls. The logger class must implement a `log` method which will be called with the [HTTParty response](https://www.rubydoc.info/github/jnunemaker/httparty/HTTParty/Response) for every remote request sent.
 
 ```ruby
-EasyMeli::AuthorizationClient.new(logger: my_logger)
-EasyMeli::ApiClient.new(access_token, logger: my_logger)
+EasyMeli.create_token('the_code_in_the_redirect', 'the_same_redirect_url_as_above', logger: my_logger)
+EasyMeli.api_client(refresh_token: refresh_token, logger: my_logger)
 ```
 
-### Complete example showing how to retrieve a user profile
+### Example of how to retrieve a user profile
 ```ruby
 EasyMeli.configure do |config|
   config.application_id = "your_app_id"
   config.secret_key = "your_secret_key"
 end
 
-authorization_client = EasyMeli::AuthorizationClient.new
-token = authorization_client.refresh_token(previously_stored_refresh_token).to_h['access_token']
-
-api_client = EasyMeli::ApiClient.new(token)
-
+api_client = EasyMeli.api_client(refresh_token: refresh_token)
 response = api_client.get('/users/me')
 
 ```

--- a/lib/easy_meli.rb
+++ b/lib/easy_meli.rb
@@ -16,4 +16,21 @@ module EasyMeli
   def self.configure
     yield(configuration)
   end
+
+  def self.authorization_url(country_code, redirect_uri)
+    EasyMeli::AuthorizationClient.authorization_url(country_code, redirect_uri)
+  end
+
+  def self.create_token(code, redirect_uri, logger: nil)
+    EasyMeli::AuthorizationClient.create_token(code, redirect_uri, logger: nil)
+  end
+
+  def self.refresh_token(refresh_token, logger: nil)
+    EasyMeli::AuthorizationClient.refresh_token(refresh_token, logger: nil)
+  end
+
+  def self.api_client(access_token: nil, refresh_token: nil, logger: nil)
+    access_token = self.refresh_token(refresh_token, logger: logger) if refresh_token
+    EasyMeli::ApiClient.new(access_token, logger: logger)
+  end
 end

--- a/lib/easy_meli.rb
+++ b/lib/easy_meli.rb
@@ -22,11 +22,11 @@ module EasyMeli
   end
 
   def self.create_token(code, redirect_uri, logger: nil)
-    EasyMeli::AuthorizationClient.create_token(code, redirect_uri, logger: nil)
+    EasyMeli::AuthorizationClient.create_token(code, redirect_uri, logger: logger)
   end
 
   def self.refresh_token(refresh_token, logger: nil)
-    EasyMeli::AuthorizationClient.refresh_token(refresh_token, logger: nil)
+    EasyMeli::AuthorizationClient.refresh_token(refresh_token, logger: logger)
   end
 
   def self.api_client(access_token: nil, refresh_token: nil, logger: nil)

--- a/lib/easy_meli/version.rb
+++ b/lib/easy_meli/version.rb
@@ -1,3 +1,3 @@
 module EasyMeli
-  VERSION = "0.3.2"
+  VERSION = "0.4.0"
 end

--- a/test/easy_meli_test.rb
+++ b/test/easy_meli_test.rb
@@ -10,4 +10,34 @@ class EasyMeliTest < Minitest::Test
     assert_equal 'test_app_id', EasyMeli.configuration.application_id
     assert_equal 'test_secret_key', EasyMeli.configuration.secret_key
   end
+
+  def test_authorization_url
+    assert EasyMeli.authorization_url(:ar, 'test')
+  end
+
+  def test_create_token
+    EasyMeli::AuthorizationClient.expects(:create_token).with('foo', 'bar', logger: nil)
+    EasyMeli.create_token('foo', 'bar')
+  end
+
+  def test_refresh_token
+    EasyMeli::AuthorizationClient.expects(:refresh_token).with('foo', logger: nil)
+    EasyMeli.refresh_token('foo')
+  end
+
+  def test_api_client_with_refresh_token
+    EasyMeli::AuthorizationClient.expects(:refresh_token).with('foo', logger: nil).returns('bar')
+    EasyMeli::ApiClient.expects(:new).with('bar', logger: nil)
+    EasyMeli.api_client(refresh_token: 'foo')
+  end
+
+  def test_api_client_with_access_token
+    EasyMeli::ApiClient.expects(:new).with('bar', logger: nil)
+    EasyMeli.api_client(access_token: 'bar')
+  end
+
+  def test_api_client_without_tokens
+    EasyMeli::ApiClient.expects(:new).with(nil, logger: nil)
+    EasyMeli.api_client
+  end
 end


### PR DESCRIPTION
…hods names which broke interface. Bumped to 0.4.0

Made changes to make it much easier to use. I bumped it to 0.4.0 because I broke the old interface in AuthorizationClient because the names conflicted with the new utility class methods. I still wanted to allow you to access the original response which is why I didn't move all the code to the instance methods. I also updated the docs.