### PR TITLE
Rename refresh token methods to access token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## V 0.5.0
+- Renamed all `refresh_token` methods to access Token to be consistent
+- `self.api_client` Prevent access_token override when initialize togehter with a refresh_token

--- a/lib/easy_meli.rb
+++ b/lib/easy_meli.rb
@@ -25,12 +25,12 @@ module EasyMeli
     EasyMeli::AuthorizationClient.create_token(code, redirect_uri, logger: logger)
   end
 
-  def self.refresh_token(refresh_token, logger: nil)
-    EasyMeli::AuthorizationClient.refresh_token(refresh_token, logger: logger)
+  def self.access_token(refresh_token, logger: nil)
+    EasyMeli::AuthorizationClient.access_token(refresh_token, logger: logger)
   end
 
   def self.api_client(access_token: nil, refresh_token: nil, logger: nil)
-    access_token = self.refresh_token(refresh_token, logger: logger) if refresh_token
+    access_token ||= self.access_token(refresh_token, logger: logger) if refresh_token
     EasyMeli::ApiClient.new(access_token, logger: logger)
   end
 end

--- a/lib/easy_meli/authorization_client.rb
+++ b/lib/easy_meli/authorization_client.rb
@@ -35,7 +35,7 @@ class EasyMeli::AuthorizationClient
     params = {
       client_id: EasyMeli.configuration.application_id,
       response_type: 'code',
-      redirect_uri: redirect_uri 
+      redirect_uri: redirect_uri
     }
     HTTParty::Request.new(:get, country_auth_url(country_code), query: params).uri.to_s
   end
@@ -49,8 +49,8 @@ class EasyMeli::AuthorizationClient
     end
   end
 
-  def self.refresh_token(refresh_token, logger: nil)
-    response = self.new(logger: logger).refresh_token_with_response(refresh_token)
+  def self.access_token(refresh_token, logger: nil)
+    response = self.new(logger: logger).access_token_with_response(refresh_token)
     if response.success?
       response.to_h[EasyMeli::AuthorizationClient::ACCESS_TOKEN_KEY]
     else
@@ -67,7 +67,7 @@ class EasyMeli::AuthorizationClient
     post_auth(query_params)
   end
 
-  def refresh_token_with_response(refresh_token)
+  def access_token_with_response(refresh_token)
     query_params = merge_auth_params(
       grant_type: 'refresh_token',
       refresh_token: refresh_token
@@ -84,7 +84,7 @@ class EasyMeli::AuthorizationClient
   end
 
   def self.country_auth_url(country_code)
-    url = BASE_AUTH_URLS[country_code.to_s.upcase.to_sym] || 
+    url = BASE_AUTH_URLS[country_code.to_s.upcase.to_sym] ||
       (raise ArgumentError.new('%s is an invalid country code' % country_code))
     [url, AUTH_PATH].join
   end

--- a/lib/easy_meli/version.rb
+++ b/lib/easy_meli/version.rb
@@ -1,3 +1,3 @@
 module EasyMeli
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end

--- a/test/authorization_client_test.rb
+++ b/test/authorization_client_test.rb
@@ -21,7 +21,7 @@ class AuthorizationClientTest < Minitest::Test
   end
 
   def test_authorization_url_with_invalid_country
-    assert_raises ArgumentError do 
+    assert_raises ArgumentError do
       EasyMeli::AuthorizationClient.authorization_url('foo', 'bar')
     end
   end
@@ -56,7 +56,7 @@ class AuthorizationClientTest < Minitest::Test
       redirect_uri: 'test_redirect_uri',
       response_status: 403
     )
-    assert_raises EasyMeli::AuthenticationError do 
+    assert_raises EasyMeli::AuthenticationError do
       EasyMeli::AuthorizationClient.create_token('test_code', 'test_redirect_uri')
     end
   end
@@ -67,27 +67,27 @@ class AuthorizationClientTest < Minitest::Test
     test_create_token_with_response(logger)
   end
 
-  def test_refresh_token
+  def test_access_token
     stub_auth_request(grant_type: 'refresh_token', refresh_token: 'test_token')
-    access_token = EasyMeli::AuthorizationClient.refresh_token('test_token')
+    access_token = EasyMeli::AuthorizationClient.access_token('test_token')
     assert_equal DUMMY_TOKEN_RESPONSE['access_token'], access_token
   end
 
-  def test_refresh_token_fail
+  def test_access_token_fail
     stub_auth_request(
       grant_type: 'refresh_token',
       refresh_token: 'test_token',
       response_status: 403)
-  
-    assert_raises EasyMeli::AuthenticationError do 
-      EasyMeli::AuthorizationClient.refresh_token('test_token')
+
+    assert_raises EasyMeli::AuthenticationError do
+      EasyMeli::AuthorizationClient.access_token('test_token')
     end
   end
 
-  def test_refresh_token_with_response(logger = nil)
+  def test_access_token_with_response(logger = nil)
     stub_auth_request(grant_type: 'refresh_token', refresh_token: 'test_token')
     response = EasyMeli::AuthorizationClient.new(logger: logger).
-      refresh_token_with_response('test_token')
+      access_token_with_response('test_token')
 
     assert_equal(DUMMY_TOKEN_RESPONSE, response.to_h)
   end
@@ -95,7 +95,7 @@ class AuthorizationClientTest < Minitest::Test
   def test_refresh_token_logger
     logger = mock()
     logger.expects(:log)
-    test_refresh_token_with_response(logger)
+    test_access_token_with_response(logger)
   end
 
   private
@@ -103,7 +103,7 @@ class AuthorizationClientTest < Minitest::Test
   def stub_auth_request(params = {})
     response_status = params.delete(:response_status) || 200
     stub_request(:post, EasyMeli::AuthorizationClient::AUTH_TOKEN_URL).
-      with(query: 
+      with(query:
         params.merge(
           client_id: 'test_app_id',
           client_secret: 'test_secret_key'

--- a/test/easy_meli_test.rb
+++ b/test/easy_meli_test.rb
@@ -20,15 +20,15 @@ class EasyMeliTest < Minitest::Test
     EasyMeli.create_token('foo', 'bar')
   end
 
-  def test_refresh_token
-    EasyMeli::AuthorizationClient.expects(:refresh_token).with('foo', logger: nil)
-    EasyMeli.refresh_token('foo')
+  def test_access_token
+    EasyMeli::AuthorizationClient.expects(:access_token).with('foo', logger: nil)
+    EasyMeli.access_token('foo')
   end
 
-  def test_api_client_with_refresh_token
-    EasyMeli::AuthorizationClient.expects(:refresh_token).with('foo', logger: nil).returns('bar')
+  def test_api_client_with_access_token
+    EasyMeli::AuthorizationClient.expects(:access_token).with('foo', logger: nil).returns('bar')
     EasyMeli::ApiClient.expects(:new).with('bar', logger: nil)
-    EasyMeli.api_client(refresh_token: 'foo')
+    EasyMeli.api_client(access_token: 'foo')
   end
 
   def test_api_client_with_access_token


### PR DESCRIPTION
We noticed the refresh_token methods actually returning an access token
using the refresh token. This updates the refresh_token methods names to
access_token to be consistent with its response.

Co-authored-by: Juan Carlos Rojas <juancarlos@easybroker.com>