### PR TITLE
Add check for 429 which now raises a TooManyRequestsError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
 
 ## V 0.5.0
-- Renamed all `refresh_token` methods to access Token to be consistent
-- `self.api_client` Prevent access_token override when initialize togehter with a refresh_token
+- `self.api_client` Prevent access_token override when initialize together with a refresh_token.
+- Raises a EasyMeli::TooManyRequestsError if a 429 response status is returned.

--- a/lib/easy_meli/errors.rb
+++ b/lib/easy_meli/errors.rb
@@ -9,4 +9,10 @@ module EasyMeli
   end
 
   class AuthenticationError < Error; end
+  
+  class TooManyRequestsError < Error
+    def initialize(response)
+      super('Too many requests', response)
+    end
+  end
 end

--- a/test/api_client_test.rb
+++ b/test/api_client_test.rb
@@ -51,6 +51,13 @@ class ApiClientTest < Minitest::Test
     assert_authorization_error('message' => 'Malformed access_token')
   end
 
+  def test_status_error
+    assert_raises EasyMeli::TooManyRequestsError do
+      stub_verb_request(:get, 'test').to_return(status: 429)
+      client.get('test')
+    end
+  end
+
   def test_array_response
     stub_verb_request(:get, 'test', query: { param1: 1, param2: 2 }).
       to_return(body: '[{}, {}]')


### PR DESCRIPTION
I added support for checking for status errors. For now it only checks for the 429 Too Many Requests error. I think this error is useful to check for since you don't want to have to check every response when using the client.