### PR TITLE
Include invalid token error as an authorization error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## V 0.6.0
+- Classify an `invalid_token` response as an `InvalidTokenError`.
+- `Malformed access_token` error changed from `AuthenticationError` to `InvalidTokenError`.
+
 ## V 0.5.0
 - `self.api_client` Prevent access_token override when initialize together with a refresh_token.
 - Raises a EasyMeli::TooManyRequestsError if a 429 response status is returned.

--- a/lib/easy_meli/api_client.rb
+++ b/lib/easy_meli/api_client.rb
@@ -5,14 +5,11 @@ class EasyMeli::ApiClient
 
   API_ROOT_URL = 'https://api.mercadolibre.com'
 
-  AUTHENTICATION_ERROR_LIST = {
-    'invalid_grant' => 'Invalid Grant',
-    'forbidden' => 'Forbidden'
-  }
-
-  ACCESS_TOKEN_ERROR_LIST = {
-    'invalid_token' => 'Invalid Token',
-    'Malformed access_token' => 'Malformed access token'
+  ERROR_LIST = {
+    'invalid_grant' => EasyMeli::InvalidGrantError,
+    'forbidden' => EasyMeli::ForbiddenError,
+    'invalid_token' => EasyMeli::InvalidTokenError,
+    'Malformed access_token' => EasyMeli::MalformedTokenError
   }
 
   STATUS_ERRORS = {
@@ -60,17 +57,13 @@ class EasyMeli::ApiClient
   end
 
   def check_authentication(response)
-    raise_errors_for(EasyMeli::AuthenticationError, AUTHENTICATION_ERROR_LIST, response)
-    raise_errors_for(EasyMeli::InvalidTokenError, ACCESS_TOKEN_ERROR_LIST, response)
-  end
-
-  def raise_errors_for(exception, error_list, response)
     response_message = error_message_from_body(response.to_h) if response.parsed_response.is_a? Hash
     return if response_message.to_s.empty?
 
-    error_list.keys.each do |key|
+    ERROR_LIST.keys.each do |key|
       if response_message.include?(key)
-        raise exception.new(error_list[key], response)
+        exception = ERROR_LIST[key]
+        raise exception.new(response)
       end
     end
   end

--- a/lib/easy_meli/api_client.rb
+++ b/lib/easy_meli/api_client.rb
@@ -5,9 +5,13 @@ class EasyMeli::ApiClient
 
   API_ROOT_URL = 'https://api.mercadolibre.com'
 
-  TOKEN_ERRORS = {
+  AUTHENTICATION_ERROR_LIST = {
     'invalid_grant' => 'Invalid Grant',
-    'forbidden' => 'Forbidden',
+    'forbidden' => 'Forbidden'
+  }
+
+  ACCESS_TOKEN_ERROR_LIST = {
+    'invalid_token' => 'Invalid Token',
     'Malformed access_token' => 'Malformed access token'
   }
 
@@ -15,7 +19,7 @@ class EasyMeli::ApiClient
     429 => EasyMeli::TooManyRequestsError
   }
 
-  base_uri API_ROOT_URL 
+  base_uri API_ROOT_URL
   headers EasyMeli::DEFAULT_HEADERS
   format :json
 
@@ -56,12 +60,17 @@ class EasyMeli::ApiClient
   end
 
   def check_authentication(response)
+    raise_errors_for(EasyMeli::AuthenticationError, AUTHENTICATION_ERROR_LIST, response)
+    raise_errors_for(EasyMeli::InvalidTokenError, ACCESS_TOKEN_ERROR_LIST, response)
+  end
+
+  def raise_errors_for(exception, error_list, response)
     response_message = error_message_from_body(response.to_h) if response.parsed_response.is_a? Hash
     return if response_message.to_s.empty?
 
-    TOKEN_ERRORS.keys.each do |key|
+    error_list.keys.each do |key|
       if response_message.include?(key)
-        raise EasyMeli::AuthenticationError.new(TOKEN_ERRORS[key], response)
+        raise exception.new(error_list[key], response)
       end
     end
   end

--- a/lib/easy_meli/errors.rb
+++ b/lib/easy_meli/errors.rb
@@ -9,7 +9,9 @@ module EasyMeli
   end
 
   class AuthenticationError < Error; end
-  
+
+  class InvalidTokenError < Error; end
+
   class TooManyRequestsError < Error
     def initialize(response)
       super('Too many requests', response)

--- a/lib/easy_meli/errors.rb
+++ b/lib/easy_meli/errors.rb
@@ -2,19 +2,59 @@ module EasyMeli
   class Error < StandardError
     attr_reader :response
 
-    def initialize(message, response)
+    def initialize(response)
       @response = response
-      super(message)
+      super(local_message)
+    end
+
+    private
+
+    def local_message
+      raise NotImplementedError
     end
   end
 
   class AuthenticationError < Error; end
 
-  class InvalidTokenError < Error; end
+  class InvalidGrantError < AuthenticationError
+    private
+
+    def local_message
+      'Invalid Grant'
+    end
+  end
+
+  class ForbiddenError < AuthenticationError
+    private
+
+    def local_message
+      'Forbidden'
+    end
+  end
+
+  class AccessTokenError < Error; end
+
+  class InvalidTokenError < AccessTokenError
+    private
+
+    def local_message
+      'Invalid Token'
+    end
+  end
+
+  class MalformedTokenError < AccessTokenError
+    private
+
+    def local_message
+      'Malformed access token'
+    end
+  end
 
   class TooManyRequestsError < Error
-    def initialize(response)
-      super('Too many requests', response)
+    private
+
+    def local_message
+      'Too many requests'
     end
   end
 end

--- a/lib/easy_meli/version.rb
+++ b/lib/easy_meli/version.rb
@@ -1,3 +1,3 @@
 module EasyMeli
-  VERSION = "0.5.0"
+  VERSION = "0.6.0"
 end

--- a/test/api_client_test.rb
+++ b/test/api_client_test.rb
@@ -83,7 +83,7 @@ class ApiClientTest < Minitest::Test
   end
 
   def assert_token_error(body)
-    assert_raises EasyMeli::InvalidTokenError do
+    assert_raises EasyMeli::AccessTokenError do
       stub_verb_request(:get, 'test', query: { param1: 1, param2: 2 }).
         to_return(body: body.to_json)
       client.get('test', query: { param1: 1, param2: 2 })

--- a/test/api_client_test.rb
+++ b/test/api_client_test.rb
@@ -44,11 +44,19 @@ class ApiClientTest < Minitest::Test
   end
 
   def test_invalid_grant_error
-    assert_authorization_error('error' => 'invalid_grant')
+    assert_authentication_error('error' => 'invalid_grant')
+  end
+
+  def test_forbidden_error
+    assert_authentication_error('error' => 'forbidden')
   end
 
   def test_message_error
-    assert_authorization_error('message' => 'Malformed access_token')
+    assert_token_error('message' => 'Malformed access_token')
+  end
+
+  def test_invalid_token_error
+    assert_token_error('error' => 'invalid_token')
   end
 
   def test_status_error
@@ -66,8 +74,16 @@ class ApiClientTest < Minitest::Test
 
   private
 
-  def assert_authorization_error(body)
+  def assert_authentication_error(body)
     assert_raises EasyMeli::AuthenticationError do
+      stub_verb_request(:get, 'test', query: { param1: 1, param2: 2 }).
+        to_return(body: body.to_json)
+      client.get('test', query: { param1: 1, param2: 2 })
+    end
+  end
+
+  def assert_token_error(body)
+    assert_raises EasyMeli::InvalidTokenError do
       stub_verb_request(:get, 'test', query: { param1: 1, param2: 2 }).
         to_return(body: body.to_json)
       client.get('test', query: { param1: 1, param2: 2 })


### PR DESCRIPTION
If a Mercado Libre account is authenticated twice, the first
authentication and the authorization tokens are invalidated.
This includes the `invalid_token` response in the token errors list.

Co-authored-by: Juan Carlos Rojas <juancarlos@easybroker.com>

