### PR TITLE
Fix raise errors bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+on:
+  pull_request:
+    branches: [ master ]
+  push:
+    branches: [ master ]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby_version: [ '2.6' ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup ruby ${{ matrix.ruby_version }}
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby_version }}
+      - name: Setup cache key and directory for gems cache
+        uses: actions/cache@v1
+        with:
+          path: vendor/bundle
+          key: ${{ runner.os }}-gem-use-ruby-${{ matrix.ruby_version }}-${{ hashFiles('**/Gemfile.lock') }}
+      - name: Bundle install
+        run: |
+          gem install bundler:1.17.0
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
+      - name: Run tests
+        run: |
+          bundle exec rake test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## V 0.6.1
+- Fix a bug in the error raising in the authorization client introduced in V 0.6.0
+
 ## V 0.6.0
 - Classify an `invalid_token` response as an `InvalidTokenError`.
 - `Malformed access_token` error changed from `AuthenticationError` to `InvalidTokenError`.

--- a/lib/easy_meli/authorization_client.rb
+++ b/lib/easy_meli/authorization_client.rb
@@ -45,7 +45,7 @@ class EasyMeli::AuthorizationClient
     if response.success?
       response.to_h
     else
-      raise EasyMeli::AuthenticationError.new('Error Creating Token', response)
+      raise EasyMeli::CreateTokenError.new(response)
     end
   end
 
@@ -54,7 +54,7 @@ class EasyMeli::AuthorizationClient
     if response.success?
       response.to_h[EasyMeli::AuthorizationClient::ACCESS_TOKEN_KEY]
     else
-      raise EasyMeli::AuthenticationError.new('Error Refreshing Token', response)
+      raise EasyMeli::InvalidTokenError.new(response)
     end
   end
 

--- a/lib/easy_meli/errors.rb
+++ b/lib/easy_meli/errors.rb
@@ -16,6 +16,14 @@ module EasyMeli
 
   class AuthenticationError < Error; end
 
+  class CreateTokenError < AuthenticationError
+    private
+
+    def local_message
+      'Error Creating Token'
+    end
+  end
+
   class InvalidGrantError < AuthenticationError
     private
 

--- a/lib/easy_meli/version.rb
+++ b/lib/easy_meli/version.rb
@@ -1,3 +1,3 @@
 module EasyMeli
-  VERSION = "0.6.0"
+  VERSION = "0.6.1"
 end

--- a/test/authorization_client_test.rb
+++ b/test/authorization_client_test.rb
@@ -79,7 +79,7 @@ class AuthorizationClientTest < Minitest::Test
       refresh_token: 'test_token',
       response_status: 403)
 
-    assert_raises EasyMeli::AuthenticationError do
+    assert_raises EasyMeli::AccessTokenError do
       EasyMeli::AuthorizationClient.access_token('test_token')
     end
   end


### PR DESCRIPTION
The authorization client has a bug in error raising. This updates the error raising in the authorization client and adds GitHub actions CI to avoid break tested code.