### PR TITLE
Update Error Classification mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## V 0.6.2
+- Update Error classification mechanism to use error message as first option
+
 ## V 0.6.1
 - Fix a bug in the error raising in the authorization client introduced in V 0.6.0
 

--- a/lib/easy_meli/version.rb
+++ b/lib/easy_meli/version.rb
@@ -1,3 +1,3 @@
 module EasyMeli
-  VERSION = "0.6.1"
+  VERSION = "0.6.2"
 end

--- a/test/api_client_test.rb
+++ b/test/api_client_test.rb
@@ -44,25 +44,37 @@ class ApiClientTest < Minitest::Test
   end
 
   def test_invalid_grant_error
-    assert_authentication_error('error' => 'invalid_grant')
+    body = {
+      "message":"Error validating grant. Your authorization code or refresh token may be expired or it was already used.",
+      "error":"invalid_grant",
+      "status":400,
+      "cause":[]
+    }
+    assert_authentication_error(body)
   end
 
   def test_forbidden_error
-    assert_authentication_error('error' => 'forbidden')
+    body = { "message":"forbidden", "error":"forbidden", "status":400, "cause":[] }
+    assert_authentication_error(body)
   end
 
   def test_message_error
-    assert_token_error('message' => 'Malformed access_token')
+    body = { "message": "Malformed access_token: test","error": "bad_request", "status": 400, "cause":[]}
+    assert_token_error(body)
   end
 
   def test_invalid_token_error
-    assert_token_error('error' => 'invalid_token')
+    body = { "message": "invalid_token", "error": "not_found", "status": 401, "cause":[] }
+    assert_token_error(body)
   end
 
-  def test_status_error
+  def test_too_many_requests_error
+    body = { "message":"","error": "too_many_requests", "status":429, "cause":[] }
+
     assert_raises EasyMeli::TooManyRequestsError do
-      stub_verb_request(:get, 'test').to_return(status: 429)
-      client.get('test')
+      stub_verb_request(:get, 'test', query: { param1: 1, param2: 2 }).
+        to_return(body: body.to_json)
+      client.get('test', query: { param1: 1, param2: 2 })
     end
   end
 


### PR DESCRIPTION
Mercado Libre doesn't have a uniform error structure. For example the
invalid_token error has in the error key "not_found"

```
{ "message": "invalid_token", "error": "not_found", "status": 401, "cause":[] }
```

Or malformed access_token comes as a bad_request error
```
{ "message": "Malformed access_token: test","error": "bad_request", "status": 400, "cause":[] }
```

This updates the error classification mechanism to use the description
as the first alternative to classify the error.