### PR TITLE
Add missing safe navigation operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## V 0.6.3
+- Fix error when the api response doesn't include error or message keys.
+- Add right error message for forbidden error.
+
 ## V 0.6.2
 - Update Error classification mechanism to use error message as first option
 

--- a/lib/easy_meli/api_client.rb
+++ b/lib/easy_meli/api_client.rb
@@ -7,7 +7,7 @@ class EasyMeli::ApiClient
 
   ERROR_LIST = {
     'Error validating grant' => EasyMeli::InvalidGrantError,
-    'forbidden' => EasyMeli::ForbiddenError,
+    'The User ID must match the consultant\'s' => EasyMeli::ForbiddenError,
     'invalid_token' => EasyMeli::InvalidTokenError,
     'Malformed access_token' => EasyMeli::MalformedTokenError,
     'too_many_requests' => EasyMeli::TooManyRequestsError

--- a/lib/easy_meli/api_client.rb
+++ b/lib/easy_meli/api_client.rb
@@ -53,7 +53,7 @@ class EasyMeli::ApiClient
   end
 
   def check_for_errors(response)
-    return unless response.parsed_response.is_a? Hash
+    return unless response.parsed_response.is_a?(Hash) && !response.body.nil?
 
     exception = error_class(response)
 
@@ -63,12 +63,10 @@ class EasyMeli::ApiClient
   end
 
   def error_class(body)
-    ERROR_LIST.find { |key, _| error_message_from_body(body).include?(key) }&.last
+    ERROR_LIST.find { |key, _| error_message_from_body(body)&.include?(key) }&.last
   end
 
   def error_message_from_body(response)
-    return if response.body.nil?
-
     response['message'].to_s.empty? ? response['error'] : response['message']
   end
 end

--- a/lib/easy_meli/version.rb
+++ b/lib/easy_meli/version.rb
@@ -1,3 +1,3 @@
 module EasyMeli
-  VERSION = "0.6.2"
+  VERSION = "0.6.3"
 end

--- a/test/api_client_test.rb
+++ b/test/api_client_test.rb
@@ -8,7 +8,10 @@ class ApiClientTest < Minitest::Test
   end
 
   def test_get
-    stub_verb_request(:get, 'test', query: { param1: 1, param2: 2 })
+    body = { "plain_text":"Hello World", "last_updated":"2020-04-23T23:45:22.000Z", "date_created":"2020-04-23T23:40:21.000Z" }
+
+    stub_verb_request(:get, 'test', query: { param1: 1, param2: 2 }).
+      to_return(body: body.to_json)
     client.get('test', query: { param1: 1, param2: 2 })
   end
 

--- a/test/api_client_test.rb
+++ b/test/api_client_test.rb
@@ -57,7 +57,13 @@ class ApiClientTest < Minitest::Test
   end
 
   def test_forbidden_error
-    body = { "message":"forbidden", "error":"forbidden", "status":400, "cause":[] }
+    body = {
+      "cause"=>[],
+      "error"=>"forbidden",
+      "message"=>"The User ID must match the consultant's",
+      "status"=>403
+    }
+
     assert_authentication_error(body)
   end
 


### PR DESCRIPTION
If the body doesn't have error or message key, the error validation
fails because we try to perform `.include?` to a nil object. This
adds a save navigation operator to avoid the scenario. Also we added
the right response for the forbidden error.

Co-authored-by: Oscar Zatarain <ozatarain@hotmail.com>
