### PR TITLE
Add unkown error to error list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## V 0.6.4
+- Add Unknown error support
+
 ## V 0.6.3
 - Fix error when the api response doesn't include error or message keys.
 - Add right error message for forbidden error.

--- a/lib/easy_meli/api_client.rb
+++ b/lib/easy_meli/api_client.rb
@@ -10,7 +10,8 @@ class EasyMeli::ApiClient
     'The User ID must match the consultant\'s' => EasyMeli::ForbiddenError,
     'invalid_token' => EasyMeli::InvalidTokenError,
     'Malformed access_token' => EasyMeli::MalformedTokenError,
-    'too_many_requests' => EasyMeli::TooManyRequestsError
+    'too_many_requests' => EasyMeli::TooManyRequestsError,
+    'unknown_error' => EasyMeli::UnknownError
   }
 
   base_uri API_ROOT_URL

--- a/lib/easy_meli/errors.rb
+++ b/lib/easy_meli/errors.rb
@@ -65,4 +65,12 @@ module EasyMeli
       'Too many requests'
     end
   end
+
+  class UnknownError < Error
+    private
+
+    def local_message
+      'Unknown Error'
+    end
+  end
 end

--- a/lib/easy_meli/version.rb
+++ b/lib/easy_meli/version.rb
@@ -1,3 +1,3 @@
 module EasyMeli
-  VERSION = "0.6.3"
+  VERSION = "0.6.4"
 end

--- a/test/api_client_test.rb
+++ b/test/api_client_test.rb
@@ -87,6 +87,16 @@ class ApiClientTest < Minitest::Test
     end
   end
 
+  def test_unkown_error
+    body = {"message":"unknown_error","error":"","status":400,"cause":[]}
+
+    assert_raises EasyMeli::UnknownError do
+      stub_verb_request(:get, 'test', query: { param1: 1, param2: 2 }).
+        to_return(body: body.to_json)
+      client.get('test', query: { param1: 1, param2: 2 })
+    end
+  end
+
   def test_array_response
     stub_verb_request(:get, 'test', query: { param1: 1, param2: 2 }).
       to_return(body: '[{}, {}]')


### PR DESCRIPTION
Currently we discovered this error if you send a random word in the
access token. Probably is the default response when the system doesn't
have a specific error to show.

Co-authored-by: Oscar Zatarain <ozatarain@hotmail.com>
