### PR TITLE
Classify code 401 as invalid token error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## V 0.6.6
+- Classify status code 401 as EasyMeli::InvalidTokenError.
+
 ## V 0.6.5
 - Move Error class search to its own class and reuse it for ApiClient and AuthorizationClient
 - Raise EasyMeli exceptions for server side errors.

--- a/lib/easy_meli/error_parser.rb
+++ b/lib/easy_meli/error_parser.rb
@@ -9,6 +9,7 @@ class EasyMeli::ErrorParser
   }
 
   STATUS_ERRORS = {
+    401 => EasyMeli::InvalidTokenError,
     500 => EasyMeli::InternalServerError,
     501 => EasyMeli::NotImplementedError,
     502 => EasyMeli::BadGatewayError,
@@ -21,7 +22,7 @@ class EasyMeli::ErrorParser
   end
 
   def self.status_error_class(response)
-    return unless self.server_side_error?(response)
+    return unless self.status_code_listed?(response) || self.server_side_error?(response)
 
     STATUS_ERRORS[response.code] || EasyMeli::ServerError
   end
@@ -34,5 +35,9 @@ class EasyMeli::ErrorParser
 
   def self.server_side_error?(response)
     response.code >= 500
+  end
+
+  def self.status_code_listed?(response)
+    STATUS_ERRORS.keys.include?(response.code)
   end
 end

--- a/lib/easy_meli/version.rb
+++ b/lib/easy_meli/version.rb
@@ -1,3 +1,3 @@
 module EasyMeli
-  VERSION = "0.6.5"
+  VERSION = "0.6.6"
 end

--- a/test/api_client_test.rb
+++ b/test/api_client_test.rb
@@ -77,6 +77,16 @@ class ApiClientTest < Minitest::Test
     assert_token_error(body)
   end
 
+  def test_unauthorized_status_code_error
+    body = { "message": "Invalid token", "error": "not_found", "status": 401, "cause":[] }
+
+    assert_raises EasyMeli::AccessTokenError do
+      stub_verb_request(:post, 'test', query: { param1: 1, param2: 2 }, body: 'param3=3').
+        to_return(body: body.to_json, status: [401, "unauthorized"])
+      client.post('test', query: { param1: 1, param2: 2 }, body: { param3: 3})
+    end
+  end
+
   def test_too_many_requests_error
     body = { "message":"","error": "too_many_requests", "status":429, "cause":[] }
 

--- a/test/error_parser_test.rb
+++ b/test/error_parser_test.rb
@@ -28,6 +28,12 @@ class ErrorParserTest < Minitest::Test
 
     assert_equal EasyMeli::ServerError, EasyMeli::ErrorParser.status_error_class(response)
 
+
+    response = mock()
+    response.stubs(code: 401)
+
+    assert_equal EasyMeli::InvalidTokenError, EasyMeli::ErrorParser.status_error_class(response)
+
     response.stubs(code: 200)
 
     assert_nil EasyMeli::ErrorParser.status_error_class(response)


### PR DESCRIPTION
MecadoLibre has not standarized the error message for invalid token at
this moment the API has shown two different responses for the same error:
```
{"message":"invalid_token","error":"not_found","status":401,"cause":[]}
```
```    
{"message":"Invalid token","cause":[],"error":"not_found","status":401}
```

This adds the 401 status code as an `EasyMeli::InvalidTokenError`.

Co-authored-by: Juan Carlos Rojas <juancarlos@easybroker.com>