### PR TITLE
Send access token in the headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## V 0.6.7
+- Send `access_token` in the Authorization Header instead of the query params [See Official Documentation](https://developers.mercadolibre.com.ar/es_ar/desarrollo-seguro#header)
+
 ## V 0.6.6
 - Classify status code 401 as EasyMeli::InvalidTokenError.
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You can also pass a logger to any methods that make remote calls. The logger cla
 
 ```ruby
 EasyMeli.create_token('the_code_in_the_redirect', 'the_same_redirect_url_as_above', logger: my_logger)
-EasyMeli.api_client(refresh_token: refresh_token, logger: my_logger)
+EasyMeli.api_client(access_token: access_token, logger: my_logger)
 ```
 
 ### Example of how to retrieve a user profile
@@ -73,8 +73,8 @@ EasyMeli.configure do |config|
   config.secret_key = "your_secret_key"
 end
 
-api_client = EasyMeli.api_client(refresh_token: refresh_token)
-response = api_client.get('/users/me')
+client = EasyMeli.api_client(access_token: access_token)
+response = client.get('/users/me')
 
 ```
 

--- a/lib/easy_meli/api_client.rb
+++ b/lib/easy_meli/api_client.rb
@@ -6,7 +6,6 @@ class EasyMeli::ApiClient
   API_ROOT_URL = 'https://api.mercadolibre.com'
 
   base_uri API_ROOT_URL
-  headers EasyMeli::DEFAULT_HEADERS
   format :json
 
   attr_reader :logger, :access_token
@@ -36,7 +35,7 @@ class EasyMeli::ApiClient
 
   def send_request(verb, path = '', params = {})
     query = params[:query] || params['query'] || {}
-    query[:access_token] = access_token if access_token
+    params[:headers] = EasyMeli::DEFAULT_HEADERS.merge(authorization_header)
 
     self.class.send(verb, path, params.merge(query)).tap do |response|
       logger&.log response
@@ -61,5 +60,11 @@ class EasyMeli::ApiClient
     if exception
       raise exception.new(response)
     end
+  end
+
+  def authorization_header
+    return {} unless access_token
+
+    { Authorization: "Bearer #{access_token}" }
   end
 end

--- a/lib/easy_meli/version.rb
+++ b/lib/easy_meli/version.rb
@@ -1,3 +1,3 @@
 module EasyMeli
-  VERSION = "0.6.6"
+  VERSION = "0.6.7"
 end

--- a/test/api_client_test.rb
+++ b/test/api_client_test.rb
@@ -143,8 +143,10 @@ class ApiClientTest < Minitest::Test
 
   def stub_verb_request(verb, path, params = {})
     params[:query] = query = params[:query] || {}
-    params[:headers] = EasyMeli::DEFAULT_HEADERS
-    query[:access_token] = client.access_token if client.access_token
+    authorization_header = client.access_token ? { Authorization: "Bearer #{client.access_token}" } : {}
+
+    params[:headers] = EasyMeli::DEFAULT_HEADERS.merge(authorization_header)
+
     url = [EasyMeli::ApiClient::API_ROOT_URL, path].join
     stub_request(verb, url).with(params)
   end

--- a/test/easy_meli_test.rb
+++ b/test/easy_meli_test.rb
@@ -25,10 +25,10 @@ class EasyMeliTest < Minitest::Test
     EasyMeli.access_token('foo')
   end
 
-  def test_api_client_with_access_token
+  def test_api_client_with_refresh_token
     EasyMeli::AuthorizationClient.expects(:access_token).with('foo', logger: nil).returns('bar')
     EasyMeli::ApiClient.expects(:new).with('bar', logger: nil)
-    EasyMeli.api_client(access_token: 'foo')
+    EasyMeli.api_client(refresh_token: 'foo')
   end
 
   def test_api_client_with_access_token


### PR DESCRIPTION
ML has updated the way that they receive the access_token, instead of
send the access token in the query params this should be send in the
headers using the Authorization header

Example: `Authorization: Bearer APP_USR-12345678-031820-X-12345678``

The documentation about this change is here
https://developers.mercadolibre.com.ar/es_ar/desarrollo-seguro#header

Co-authored-by: Oscar Zatarain <ozatarain@hotmail.com>
