### PR TITLE
Fix parse error response

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea/
 /.bundle/
 /.yardoc
 /_yardoc/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## V 0.6.8
+- Fix error when the api response includes error_description instead of message key.
+
 ## V 0.6.7
 - Send `access_token` in the Authorization Header instead of the query params [See Official Documentation](https://developers.mercadolibre.com.ar/es_ar/desarrollo-seguro#header)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    easy_meli (0.6.7)
+    easy_meli (0.6.8)
       httparty (~> 0.18)
 
 GEM

--- a/lib/easy_meli/error_parser.rb
+++ b/lib/easy_meli/error_parser.rb
@@ -1,4 +1,6 @@
 class EasyMeli::ErrorParser
+  ERROR_FIELDS = %w[message error error_description]
+
   ERROR_LIST = {
     'Error validating grant' => EasyMeli::InvalidGrantError,
     'The User ID must match the consultant\'s' => EasyMeli::ForbiddenError,
@@ -18,9 +20,11 @@ class EasyMeli::ErrorParser
   }
 
   def self.error_class(response)
-    find_in_error_list(response['message']) ||
-    find_in_error_list(response['error']) ||
-    find_in_error_list(response['error_description'])
+    ERROR_FIELDS.each do |field|
+      error = find_in_error_list(response[field])
+      return error if error
+    end
+    nil
   end
 
   def self.status_error_class(response)
@@ -32,6 +36,8 @@ class EasyMeli::ErrorParser
   private
 
   def self.find_in_error_list(response_field)
+    return if response_field.to_s.empty?
+
     ERROR_LIST.find { |key, _| response_field&.include?(key) }&.last
   end
 

--- a/lib/easy_meli/error_parser.rb
+++ b/lib/easy_meli/error_parser.rb
@@ -18,7 +18,9 @@ class EasyMeli::ErrorParser
   }
 
   def self.error_class(response)
-    ERROR_LIST.find { |key, _| self.error_message_from_body(response)&.include?(key) }&.last
+    find_in_error_list(response['message']) ||
+    find_in_error_list(response['error']) ||
+    find_in_error_list(response['error_description'])
   end
 
   def self.status_error_class(response)
@@ -29,8 +31,8 @@ class EasyMeli::ErrorParser
 
   private
 
-  def self.error_message_from_body(response)
-    response['message'].to_s.empty? ? response['error'] : response['message']
+  def self.find_in_error_list(response_field)
+    ERROR_LIST.find { |key, _| response_field&.include?(key) }&.last
   end
 
   def self.server_side_error?(response)

--- a/lib/easy_meli/version.rb
+++ b/lib/easy_meli/version.rb
@@ -1,3 +1,3 @@
 module EasyMeli
-  VERSION = "0.6.7"
+  VERSION = "0.6.8"
 end

--- a/test/api_client_test.rb
+++ b/test/api_client_test.rb
@@ -48,7 +48,7 @@ class ApiClientTest < Minitest::Test
 
   def test_invalid_grant_error
     body = {
-      "message":"Error validating grant. Your authorization code or refresh token may be expired or it was already used.",
+      "error_description":"Error validating grant. Your authorization code or refresh token may be expired or it was already used.",
       "error":"invalid_grant",
       "status":400,
       "cause":[]

--- a/test/authorization_client_test.rb
+++ b/test/authorization_client_test.rb
@@ -86,7 +86,7 @@ class AuthorizationClientTest < Minitest::Test
 
   def test_access_token_invalid_grant
     body = {
-      "message":"Error validating grant. Your authorization code or refresh token may be expired or it was already used.",
+      "error_description":"Error validating grant. Your authorization code or refresh token may be expired or it was already used.",
       "error":"invalid_grant",
       "status":400,
       "cause":[]

--- a/test/error_parser_test.rb
+++ b/test/error_parser_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class ErrorParserTest < Minitest::Test
   def test_error_class
     body = {
-      "message" => "Error validating grant. Your authorization code or refresh token may be expired or it was already used.",
+      "error_description" => "Error validating grant. Your authorization code or refresh token may be expired or it was already used.",
       "error" => "invalid_grant",
       "status" => 400,
       "cause" => []


### PR DESCRIPTION
In certain instances, MercadoLibre deviates from the usual message key and instead utilizes error_description to send error responses. This adjustment has been made to ensure accurate parsing of errors in that cases.