### PR TITLE
Update httparty from 0.18 to 0.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## V 0.6.9
+- Update httparty dependency from 0.18 to 0.21
+
 ## V 0.6.8
 - Fix error when the api response includes error_description instead of message key.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    easy_meli (0.6.8)
-      httparty (~> 0.18)
+    easy_meli (0.6.9)
+      httparty (~> 0.21)
 
 GEM
   remote: https://rubygems.org/
@@ -13,13 +13,11 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     hashdiff (1.0.1)
-    httparty (0.18.1)
-      mime-types (~> 3.0)
+    httparty (0.21.0)
+      mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
     method_source (1.0.0)
-    mime-types (3.3.1)
-      mime-types-data (~> 3.2015)
-    mime-types-data (3.2020.1104)
+    mini_mime (1.1.2)
     minitest (5.14.0)
     mocha (1.11.2)
     multi_xml (0.6.0)

--- a/easy_meli.gemspec
+++ b/easy_meli.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "httparty", "~> 0.18"
+  spec.add_dependency "httparty", "~> 0.21"
 
   spec.add_development_dependency "bundler", "~> 2.2.24"
   spec.add_development_dependency "rake", "~> 13.0"

--- a/lib/easy_meli/version.rb
+++ b/lib/easy_meli/version.rb
@@ -1,3 +1,3 @@
 module EasyMeli
-  VERSION = "0.6.8"
+  VERSION = "0.6.9"
 end


### PR DESCRIPTION
This is a low priority update for [security reasons](https://github.com/easybroker/easy_meli/security/dependabot/2). Only httparty gem and [dependencies](https://rubygems.org/gems/httparty/versions/0.21.0/dependencies) will be updated.