### PR TITLE
[sc-65405] Update addressable to 2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## V 0.6.19
+- Update addressable from 2.8.8 to 2.9.0 (security fix for ReDoS vulnerability in Addressable templates)
+
 ## V 0.6.18
 - Update httparty from ~> 0.21 to ~> 0.24 (security fix for CVE-2025-68696 - SSRF vulnerability)
 - Fix tests to use proper path format with leading slash

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.8)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     bigdecimal (4.0.1)
     coderay (1.1.3)
@@ -33,7 +33,7 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
       reline (>= 0.6.0)
-    public_suffix (7.0.0)
+    public_suffix (7.0.5)
     rake (13.3.1)
     reline (0.6.3)
       io-console (~> 0.5)

--- a/lib/easy_meli/version.rb
+++ b/lib/easy_meli/version.rb
@@ -1,3 +1,3 @@
 module EasyMeli
-  VERSION = '0.6.18'
+  VERSION = '0.6.19'
 end


### PR DESCRIPTION
### Summary
Updates the transitive `addressable` dependency in `easy_meli` to the patched 2.9.0 release.

### Context
Shortcut story `sc-65405` tracks a Dependabot security alert for `addressable` in this repository.

### Solution
Refreshed `Gemfile.lock` with Bundler so the test dependency chain now resolves `addressable` 2.9.0 and `public_suffix` 7.0.5.